### PR TITLE
Fixed rooms api endpoint output

### DIFF
--- a/adventure/api.py
+++ b/adventure/api.py
@@ -14,7 +14,7 @@ import json
 @api_view(["GET"])
 def rooms(request):
     room_list = []
-    for room in Room.objects.all():
+    for room in Room.objects.all().order_by('id'):
         room_list.append({"id":room.id, "title":room.title, "description": room.description, "n_to":room.n_to, "s_to":room.s_to, "e_to":room.e_to, "w_to":room.w_to, "players":room.playerNames(request.user.player.id)})
     return JsonResponse(room_list, safe = False)
 


### PR DESCRIPTION
The `rooms` endpoint returned the rooms in a seemingly random order. This fix will make sure that the rooms are returned in ascending order by `id` number. 